### PR TITLE
feat: 사용자 도메인 보완 및 OAuth2 기반 인증 구조 개선

### DIFF
--- a/src/main/java/com/woochang/highticket/domain/BaseTimeEntity.java
+++ b/src/main/java/com/woochang/highticket/domain/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package com.woochang.highticket.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    protected LocalDateTime createdAt;
+
+    @LastModifiedDate
+    protected LocalDateTime updatedAt;
+}

--- a/src/main/java/com/woochang/highticket/domain/user/LoginType.java
+++ b/src/main/java/com/woochang/highticket/domain/user/LoginType.java
@@ -1,0 +1,8 @@
+package com.woochang.highticket.domain.user;
+
+public enum LoginType {
+
+    KAKAO,
+
+    GOOGLE;
+}

--- a/src/main/java/com/woochang/highticket/domain/user/Role.java
+++ b/src/main/java/com/woochang/highticket/domain/user/Role.java
@@ -1,0 +1,12 @@
+package com.woochang.highticket.domain.user;
+
+public enum Role {
+
+    USER,
+
+    ADMIN;
+
+    public String getAuthority() {
+        return "ROLE_" + name();
+    }
+}

--- a/src/main/java/com/woochang/highticket/domain/user/User.java
+++ b/src/main/java/com/woochang/highticket/domain/user/User.java
@@ -1,34 +1,63 @@
 package com.woochang.highticket.domain.user;
 
+import com.woochang.highticket.domain.BaseTimeEntity;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.util.Map;
 
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Table(name = "users")
-public class User {
+public class User extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(length = 50, nullable = false)
+    @Column(length = 100, nullable = false)
     private String email;
 
-    @Column(length = 10, nullable = false)
-    private String loginType;
+    @Column(length = 30, nullable = false)
+    private String nickname;
 
-    @Column(nullable = false)
-    private LocalDateTime createdAt;
+    @Column(length = 20, nullable = false)
+    @Enumerated(EnumType.STRING)
+    private LoginType loginType;
 
+    @Column(length = 20, nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Role role;
 
-    public User(String email, String loginType, LocalDateTime createdAt) {
+    public User(String email, String nickname, LoginType loginType, Role role) {
         this.email = email;
+        this.nickname = nickname;
         this.loginType = loginType;
-        this.createdAt = createdAt;
+        this.role = role;
+    }
+
+    // OAuth2 사용자 생성
+    public static User ofOAuth2(String email, String nickname, LoginType loginType) {
+        return new User(email, nickname, loginType, Role.USER);
+    }
+
+    public void changeNickname(String newNickname) {
+        this.nickname = newNickname;
+    }
+
+    public String getUserIdString() {
+        return id.toString();
+    }
+
+    // OAuth2 attributes 생성
+    public Map<String, Object> toOAuth2Attribute() {
+        return Map.of(
+                "email", this.email,
+                "nickname", this.nickname,
+                "loginType", this.nickname
+        );
     }
 }

--- a/src/main/java/com/woochang/highticket/domain/user/security/CustomOAuth2User.java
+++ b/src/main/java/com/woochang/highticket/domain/user/security/CustomOAuth2User.java
@@ -1,0 +1,37 @@
+package com.woochang.highticket.domain.user.security;
+
+import com.woochang.highticket.domain.user.Role;
+import com.woochang.highticket.domain.user.User;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+@RequiredArgsConstructor
+public class CustomOAuth2User implements OAuth2User {
+
+    @Getter
+    private final User user;
+    private final Map<String, Object> attributes;
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return this.attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority(Role.USER.getAuthority()));
+    }
+
+    @Override
+    public String getName() {
+        return user.getUserIdString();
+    }
+
+}

--- a/src/main/java/com/woochang/highticket/global/config/JpaConfig.java
+++ b/src/main/java/com/woochang/highticket/global/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.woochang.highticket.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/src/main/java/com/woochang/highticket/global/config/JwtProperties.java
+++ b/src/main/java/com/woochang/highticket/global/config/JwtProperties.java
@@ -1,12 +1,12 @@
 package com.woochang.highticket.global.config;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "jwt")
 @Getter
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class JwtProperties {
 
     private final long accessTokenExpiryMs;

--- a/src/main/java/com/woochang/highticket/global/config/SecurityConfig.java
+++ b/src/main/java/com/woochang/highticket/global/config/SecurityConfig.java
@@ -3,14 +3,18 @@ package com.woochang.highticket.global.config;
 import com.woochang.highticket.global.security.jwt.JwtAccessDeniedHandler;
 import com.woochang.highticket.global.security.jwt.JwtAuthenticationEntryPoint;
 import com.woochang.highticket.global.security.jwt.JwtAuthenticationFilter;
+import com.woochang.highticket.global.security.oauth2.OAuth2SuccessHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 import org.springframework.security.config.web.server.SecurityWebFiltersOrder;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.server.SecurityWebFilterChain;
 
 @Configuration
@@ -23,6 +27,12 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+    private final OAuth2SuccessHandler oAuth2SuccessHandler;
+
+    @Bean
+    public OAuth2UserService<OAuth2UserRequest, OAuth2User> delegateOAuth2UserService() {
+        return new DefaultOAuth2UserService();
+    }
 
     @Bean
     public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http) {
@@ -33,10 +43,12 @@ public class SecurityConfig {
                 .csrf(ServerHttpSecurity.CsrfSpec::disable) // CSRF 보호 비활성화
                 .authorizeExchange(exchanges -> {
                     exchanges
-                            .pathMatchers("/", "/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**").permitAll()
+                            .pathMatchers("/", "/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**", "/login/oauth2/**", "/oauth2/authorization/**").permitAll()
                             .anyExchange().denyAll();
                 })
-                .oauth2Login(Customizer.withDefaults()) // OAuth2 로그인 활성화
+                .oauth2Login(spec -> spec
+                        .authenticationSuccessHandler(oAuth2SuccessHandler)
+                ) // OAuth2 로그인 활성화
                 .addFilterAt(jwtAuthenticationFilter, SecurityWebFiltersOrder.AUTHENTICATION)
                 .exceptionHandling(spec -> spec
                         .authenticationEntryPoint(jwtAuthenticationEntryPoint)

--- a/src/main/java/com/woochang/highticket/global/security/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/woochang/highticket/global/security/jwt/JwtAuthenticationEntryPoint.java
@@ -25,7 +25,5 @@ public class JwtAuthenticationEntryPoint implements ServerAuthenticationEntryPoi
         DataBuffer buffer = response.bufferFactory().wrap(bytes);
 
         return response.writeWith(Mono.just(buffer));
-
-
     }
 }

--- a/src/main/java/com/woochang/highticket/global/security/oauth2/OAuth2Attribute.java
+++ b/src/main/java/com/woochang/highticket/global/security/oauth2/OAuth2Attribute.java
@@ -1,0 +1,48 @@
+package com.woochang.highticket.global.security.oauth2;
+
+import com.woochang.highticket.domain.user.LoginType;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@Getter
+public class OAuth2Attribute {
+
+    private final String email;
+    private final String nickname;
+    private final LoginType loginType;
+
+    public static OAuth2Attribute of(String registrationId, Map<String, Object> attributes){
+        return switch (registrationId) {
+            case "google" -> ofGoogle(attributes);
+            case "kakao" -> ofKakao(attributes);
+            default -> throw new IllegalArgumentException("지원하지 않는 로그인 유형: " + registrationId);
+        };
+    }
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("email", email);
+        map.put("nickname", nickname);
+        map.put("loginType", loginType.name());
+        return map;
+    }
+
+    private static OAuth2Attribute ofGoogle(Map<String, Object> attributes) {
+        String email = (String) attributes.get("email");
+        String nickname = (String) attributes.get("name");
+        return new OAuth2Attribute(email, nickname, LoginType.GOOGLE);
+    }
+
+    private static OAuth2Attribute ofKakao(Map<String, Object> attributes) {
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+
+        String email = (String) kakaoAccount.get("email");
+        String nickname = (String) profile.get("nickname");
+        return new OAuth2Attribute(email, nickname, LoginType.KAKAO);
+    }
+}

--- a/src/main/java/com/woochang/highticket/global/security/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/woochang/highticket/global/security/oauth2/OAuth2SuccessHandler.java
@@ -1,0 +1,28 @@
+package com.woochang.highticket.global.security.oauth2;
+
+import com.woochang.highticket.dto.auth.TokenDto;
+import com.woochang.highticket.service.auth.TokenService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.server.WebFilterExchange;
+import org.springframework.security.web.server.authentication.ServerAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2SuccessHandler implements ServerAuthenticationSuccessHandler {
+
+    private final TokenService tokenService;
+
+    @Override
+    public Mono<Void> onAuthenticationSuccess(WebFilterExchange exchange, Authentication auth) {
+        ServerHttpResponse response = exchange.getExchange().getResponse();
+        TokenDto tokenDto = tokenService.issueToken(auth);
+
+        response.getHeaders().add("Authorization", "Bearer " + tokenDto.getAccessToken());
+
+        return response.setComplete();
+    }
+}

--- a/src/main/java/com/woochang/highticket/internal/unused/domain/user/security/CustomUserDetails.java
+++ b/src/main/java/com/woochang/highticket/internal/unused/domain/user/security/CustomUserDetails.java
@@ -1,7 +1,7 @@
-package com.woochang.highticket.domain.user.security;
+package com.woochang.highticket.internal.unused.domain.user.security;
 
 import com.woochang.highticket.domain.user.User;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -9,18 +9,18 @@ import org.springframework.security.core.userdetails.UserDetails;
 import java.util.Collection;
 import java.util.List;
 
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class CustomUserDetails implements UserDetails {
     private final User user;
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of(new SimpleGrantedAuthority("ROLE_USER")); // 모든 사용자에게 기보적으로 ROLE_USER 권한 부여
+        return List.of(new SimpleGrantedAuthority(user.getRole().getAuthority()));
     }
 
     @Override
     public String getUsername() {
-        return user.getId().toString();
+        return user.getUserIdString();
     }
 
     @Override

--- a/src/main/java/com/woochang/highticket/internal/unused/service/user/CustomUserDetailsService.java
+++ b/src/main/java/com/woochang/highticket/internal/unused/service/user/CustomUserDetailsService.java
@@ -1,16 +1,15 @@
-package com.woochang.highticket.service.user;
+package com.woochang.highticket.internal.unused.service.user;
 
 import com.woochang.highticket.domain.user.User;
-import com.woochang.highticket.domain.user.security.CustomUserDetails;
+import com.woochang.highticket.internal.unused.domain.user.security.CustomUserDetails;
 import com.woochang.highticket.repository.user.UserRepository;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.stereotype.Service;
 
-@Service
-@AllArgsConstructor
+//@Service
+@RequiredArgsConstructor
 public class CustomUserDetailsService implements UserDetailsService {
 
     private final UserRepository userRepository;
@@ -25,3 +24,4 @@ public class CustomUserDetailsService implements UserDetailsService {
         return new CustomUserDetails(user);
     }
 }
+

--- a/src/main/java/com/woochang/highticket/repository/user/UserRepository.java
+++ b/src/main/java/com/woochang/highticket/repository/user/UserRepository.java
@@ -1,7 +1,15 @@
 package com.woochang.highticket.repository.user;
 
+import com.woochang.highticket.domain.user.LoginType;
 import com.woochang.highticket.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByEmail(String email);
+
+    Optional<User> findByEmailAndLoginType(String email, LoginType loginType);
+
 }

--- a/src/main/java/com/woochang/highticket/service/user/CustomOAuth2UserService.java
+++ b/src/main/java/com/woochang/highticket/service/user/CustomOAuth2UserService.java
@@ -1,0 +1,44 @@
+package com.woochang.highticket.service.user;
+
+import com.woochang.highticket.domain.user.User;
+import com.woochang.highticket.domain.user.security.CustomOAuth2User;
+import com.woochang.highticket.global.security.oauth2.OAuth2Attribute;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.ReactiveOAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CustomOAuth2UserService implements ReactiveOAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    private final UserService userService;
+    private final OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate;
+
+    @Override
+    public Mono<OAuth2User> loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+
+        OAuth2User oAuth2User = delegate.loadUser(userRequest);
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+
+        OAuth2Attribute oAuth2Attribute = OAuth2Attribute.of(registrationId, attributes);
+        log.info("OAuth2 attributes: {}", attributes);
+        User user = userService.findOrCreateUser(oAuth2Attribute.getEmail(), oAuth2Attribute.getNickname(), oAuth2Attribute.getLoginType());
+
+        return Mono.just(new CustomOAuth2User(user, oAuth2Attribute.toMap()));
+    }
+
+    public CustomOAuth2User loadByUserId(String userId) {
+        User user = userService.findById(Long.parseLong(userId));
+        return new CustomOAuth2User(user, user.toOAuth2Attribute());
+    }
+}

--- a/src/main/java/com/woochang/highticket/service/user/UserService.java
+++ b/src/main/java/com/woochang/highticket/service/user/UserService.java
@@ -1,0 +1,25 @@
+package com.woochang.highticket.service.user;
+
+import com.woochang.highticket.domain.user.LoginType;
+import com.woochang.highticket.domain.user.User;
+import com.woochang.highticket.repository.user.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public User findOrCreateUser(String email, String nickname, LoginType loginType) {
+        return userRepository.findByEmailAndLoginType(email, loginType)
+                .orElseGet(() -> userRepository.save(User.ofOAuth2(email, nickname, loginType)));
+    }
+
+    public User findById(Long id) {
+        return userRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다: " + id));
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -31,8 +31,8 @@ spring:
             redirect-uri: ${KAKAO_REDIRECT_URI}
             authorization-grant-type: authorization_code
             scope:
+              - account_email
               - profile_nickname
-              - profile_image
             client-authentication-method: client_secret_post
 
         provider:
@@ -42,10 +42,21 @@ spring:
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
 
+# JPA 설정
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        use_sql_comments: true
+    show-sql: true
+
 # 로그 설정
 logging:
   level:
-    root: warn
+    root: info
     org.hibernate.sql: debug
     org.hibernate.type: trace
     org.springframework.security: debug
@@ -55,4 +66,3 @@ jwt:
   access-token-expiry-ms: 3600000             # 1시간
   refresh-token-expiry-ms: 604800000          # 7일
   refresh-token-renew-threshold-ms: 86400000  # 1일
-

--- a/src/test/java/com/woochang/highticket/OAuth2TestConfig.java
+++ b/src/test/java/com/woochang/highticket/OAuth2TestConfig.java
@@ -1,0 +1,18 @@
+package com.woochang.highticket;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+@TestConfiguration
+public class OAuth2TestConfig {
+
+
+    @Bean
+    OAuth2UserService<OAuth2UserRequest, OAuth2User> delegateOAuth2UserService() {
+        return new DefaultOAuth2UserService();
+    }
+}

--- a/src/test/java/com/woochang/highticket/repository/user/UserRepositoryTest.java
+++ b/src/test/java/com/woochang/highticket/repository/user/UserRepositoryTest.java
@@ -1,0 +1,107 @@
+package com.woochang.highticket.repository.user;
+
+import com.woochang.highticket.domain.user.LoginType;
+import com.woochang.highticket.domain.user.User;
+import com.woochang.highticket.global.config.JpaConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import(JpaConfig.class)
+class UserRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = User.ofOAuth2("test@example.com", "test", LoginType.GOOGLE);
+    }
+
+    @Test
+    @DisplayName("사용자 저장 및 매핑 검증")
+    public void saveUser_success() {
+        // given - init
+
+        // when
+        User savedUser = userRepository.save(user);
+
+        // then
+        assertThat(savedUser.getId()).isNotNull();
+        assertThat(savedUser.getEmail()).isEqualTo("test@example.com");
+        assertThat(savedUser.getNickname()).isEqualTo("test");
+        assertThat(savedUser.getLoginType()).isEqualTo(LoginType.GOOGLE);
+        assertThat(savedUser.getCreatedAt()).isNotNull();
+        assertThat(savedUser.getUpdatedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("이메일로 사용자 조회")
+    public void findUser_byEmail_success() {
+        // given
+        User savedUser = userRepository.save(user);
+
+        // when
+        Optional<User> foundUser = userRepository.findByEmail(savedUser.getEmail());
+
+        // then
+        assertThat(foundUser).isPresent();
+        assertThat(foundUser.get().getId()).isEqualTo(savedUser.getId());
+    }
+
+    @Test
+    @DisplayName("이메일과 로그인 타입으로 사용자 조회")
+    public void findUser_byEmailAndLoginType_success() {
+        // given
+        User savedUser = userRepository.save(user);
+
+        // when
+        Optional<User> foundUser = userRepository.findByEmailAndLoginType(savedUser.getEmail(), savedUser.getLoginType());
+
+        // then
+        assertThat(foundUser).isPresent();
+        assertThat(foundUser.get().getId()).isEqualTo(savedUser.getId());
+    }
+    
+    @Test
+    @DisplayName("사용자 수정 시 updatedAt 시간 갱신 확인")        
+    public void updateUser_updatesUpdatedAt_success() throws InterruptedException {
+        // given 
+        User savedUser = userRepository.save(user);
+        userRepository.flush();
+        LocalDateTime firstUpdatedAt = savedUser.getUpdatedAt();
+
+        // when
+        Thread.sleep(100);
+        savedUser.changeNickname("newNickname");
+        userRepository.flush();
+
+        // then
+        assertThat(savedUser.getUpdatedAt()).isAfter(firstUpdatedAt);
+    }
+
+    @Test
+    @DisplayName("이메일 누락 시 저장 예외 발생")
+    public void emailIsNull_throwException () {
+        // given
+        User invalidUser = User.ofOAuth2(null, "testNickname", LoginType.GOOGLE);
+
+        // when & then
+        assertThatThrownBy(() -> userRepository.save(invalidUser)).isInstanceOf(DataIntegrityViolationException.class);
+    }
+}

--- a/src/test/java/com/woochang/highticket/service/user/CustomOAuth2UserServiceTest.java
+++ b/src/test/java/com/woochang/highticket/service/user/CustomOAuth2UserServiceTest.java
@@ -1,0 +1,62 @@
+package com.woochang.highticket.service.user;
+
+import com.woochang.highticket.domain.user.LoginType;
+import com.woochang.highticket.domain.user.security.CustomOAuth2User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Map;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CustomOAuth2UserServiceTest {
+
+    @Mock
+    OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate;
+
+    @Mock
+    UserService userService;
+
+    @InjectMocks
+    CustomOAuth2UserService customOAuth2UserService;
+
+    @Test
+    @DisplayName("OAuth2 인증 후에 사용자 정보를 로드 후 CustomOAuth2User로 반환")
+    public void loadUserByOAuth2User_success() {
+        // given
+        OAuth2UserRequest userRequest = mock(OAuth2UserRequest.class);
+        ClientRegistration registration = mock(ClientRegistration.class);
+        when(userRequest.getClientRegistration()).thenReturn(registration);
+        when(registration.getRegistrationId()).thenReturn("google");
+
+        Map<String, Object> attributes = Map.of(
+                "email", "test@example.com",
+                "name", "test"
+        );
+
+        OAuth2User mockOAuth2User = mock(OAuth2User.class);
+        when(mockOAuth2User.getAttributes()).thenReturn(attributes);
+        when(delegate.loadUser(userRequest)).thenReturn(mockOAuth2User);
+
+        // when
+        OAuth2User result = customOAuth2UserService.loadUser(userRequest).block();
+
+        // then
+        assertThat(result).isInstanceOf(CustomOAuth2User.class);
+        verify(userService).findOrCreateUser("test@example.com", "테스트", LoginType.GOOGLE);
+
+        CustomOAuth2User customOAuth2User = (CustomOAuth2User) result;
+        assertThat(customOAuth2User.getAttributes().get("email")).isEqualTo("test@example.com");
+        assertThat(customOAuth2User.getAttributes().get("nickname")).isEqualTo("테스트");
+    }
+}

--- a/src/test/java/com/woochang/highticket/service/user/UserServiceTest.java
+++ b/src/test/java/com/woochang/highticket/service/user/UserServiceTest.java
@@ -1,0 +1,73 @@
+package com.woochang.highticket.service.user;
+
+import com.woochang.highticket.domain.user.LoginType;
+import com.woochang.highticket.domain.user.User;
+import com.woochang.highticket.repository.user.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    UserRepository userRepository;
+
+    @InjectMocks
+    UserService userService;
+
+    @Test
+    @DisplayName("사용자 조회 후 없으면 생성")
+    public void findOrCreateUser_notExist_success() {
+        // given
+        String email = "test@example.com";
+        String nickname = "test";
+        LoginType loginType = LoginType.GOOGLE;
+
+        User createdUser = User.ofOAuth2(email, nickname, loginType);
+
+        when(userRepository.findByEmailAndLoginType(email, loginType))
+                .thenReturn(Optional.empty());
+
+        when(userRepository.save(any(User.class))).thenReturn(createdUser);
+
+        // when
+        User result = userService.findOrCreateUser(email, nickname, loginType);
+
+        // then
+        assertThat(result).isEqualTo(createdUser);
+        assertThat(result.getEmail()).isEqualTo(email);
+        assertThat(result.getNickname()).isEqualTo(nickname);
+        assertThat(result.getLoginType()).isEqualTo(loginType);
+    }
+
+    @Test
+    @DisplayName("사용자 조회 후 존재하면 반환")
+    public void findOrCreateUser_exist_success() {
+        // given
+        String email = "test@example.com";
+        String nickname = "test";
+        LoginType loginType = LoginType.GOOGLE;
+
+        User existingUser = User.ofOAuth2(email, nickname, loginType);
+
+        when(userRepository.findByEmailAndLoginType(email, loginType))
+                .thenReturn(Optional.of(existingUser));
+
+        // when
+        User result = userService.findOrCreateUser(email, nickname, loginType);
+
+        // then
+        assertThat(result).isEqualTo(existingUser);
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- HIT-31 ~ HIT -35


## 주요 구현 요약
- `CustomOAuth2User`, `OAuth2Attribute` 도입 및 적용
- OAuth2 로그인 성공 시 사용자 자동 등록
- `JwtTokenProvider`, `TokenService` 로직 개선
- 주요 테스트에 대한 작성 및 수정 후 테스트 통과 확인

## 참고사항
- PR 제목에도 Conventional Commits 규칙 적용
- 기존 `UserDetailsService` 미사용
- `@AllArgsConstructor` → `@RequiredArgsConstructor` 변경
- `SecurityConfig`에 OAuth2 관련 빈 추가

---

## 추가 코멘트 
이번 PR은 사용자 도메인 설계에 대한 개선과 JWT 발급 로직에 대해서 기존에 부족했던 점들에 대해서 정리를 중심으로 진행하였습니다.

- `OAuth2SuccessHandler` 클래스에 대해서 Authorization 헤더를 응답으로 내려보내는 현재 방식은 브라우저 환경 및 CORS 정책에 따라 제한이 있을 수 있으므로 향후 보완이 필요한 부분으로 인식됩니다.

- `OAuth2Attribute` 클래스에 대해서 발견된 강제 캐스팅을 하고 값을 꺼내는 방식의 안정성에 대해서도 문제가 있다고 생각하기 때문에 추후에 Provider 별로 DTO + 전략 패턴 조합으로 보완할 예정입니다.

> [PR 리뷰 문서](https://hwc1156.atlassian.net/wiki/spaces/hit/pages/16547842/PR) 