### PR TITLE
feat: 행사장 도메인 구현

### DIFF
--- a/src/main/java/com/woochang/highticket/controller/venue/VenueController.java
+++ b/src/main/java/com/woochang/highticket/controller/venue/VenueController.java
@@ -1,0 +1,51 @@
+package com.woochang.highticket.controller.venue;
+
+import com.woochang.highticket.domain.venue.Venue;
+import com.woochang.highticket.dto.venue.VenueCreateRequest;
+import com.woochang.highticket.dto.venue.VenueUpdateRequest;
+import com.woochang.highticket.global.response.ApiResponse;
+import com.woochang.highticket.service.venue.VenueService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/venues")
+@RequiredArgsConstructor
+public class VenueController {
+
+    private final VenueService venueService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<Venue>>> getAllVenues() {
+        List<Venue> venues = venueService.findAll();
+        return ResponseEntity.ok(ApiResponse.success(venues));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<Venue>> getVenue(@PathVariable Long id) {
+        Venue venue = venueService.findVenue(id);
+        return ResponseEntity.ok(ApiResponse.success(venue));
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<Void>> createVenue(@RequestBody @Valid VenueCreateRequest request) {
+        venueService.createVenue(request);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<ApiResponse<Void>> updateVenue(@PathVariable Long id, @RequestBody @Valid VenueUpdateRequest request) {
+        venueService.updateVenue(id, request);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse<Void>> deleteVenue(@PathVariable Long id) {
+        venueService.deleteVenue(id);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+}

--- a/src/main/java/com/woochang/highticket/domain/venue/Venue.java
+++ b/src/main/java/com/woochang/highticket/domain/venue/Venue.java
@@ -1,0 +1,43 @@
+package com.woochang.highticket.domain.venue;
+
+import com.woochang.highticket.domain.BaseTimeEntity;
+import com.woochang.highticket.dto.venue.VenueCreateRequest;
+import com.woochang.highticket.dto.venue.VenueUpdateRequest;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "venues")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Venue extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    Long id;
+
+    @Column(length = 50, nullable = false)
+    String name;
+    @Column(length = 100, nullable = false)
+    String location;
+    @Column(nullable = false)
+    int capacity;
+
+    public Venue(String name, String location, int capacity) {
+        this.name = name;
+        this.location = location;
+        this.capacity = capacity;
+    }
+
+    public static Venue of(VenueCreateRequest request) {
+        return new Venue(request.getName(), request.getLocation(), request.getCapacity());
+    }
+
+    public void updateWith(VenueUpdateRequest request) {
+        if (request.getName() != null) this.name = request.getName();
+        if (request.getLocation() != null) this.location = request.getLocation();
+        if (request.getCapacity() != null) this.capacity = request.getCapacity();
+    }
+}

--- a/src/main/java/com/woochang/highticket/dto/venue/VenueCreateRequest.java
+++ b/src/main/java/com/woochang/highticket/dto/venue/VenueCreateRequest.java
@@ -1,0 +1,27 @@
+package com.woochang.highticket.dto.venue;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class VenueCreateRequest {
+
+    @NotBlank
+    private String name;
+
+    @NotBlank
+    private String location;
+
+    @Positive
+    private Integer capacity;
+
+    public VenueCreateRequest(String name, String location, int capacity) {
+        this.name = name;
+        this.location = location;
+        this.capacity = capacity;
+    }
+}

--- a/src/main/java/com/woochang/highticket/dto/venue/VenueUpdateRequest.java
+++ b/src/main/java/com/woochang/highticket/dto/venue/VenueUpdateRequest.java
@@ -1,0 +1,20 @@
+package com.woochang.highticket.dto.venue;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class VenueUpdateRequest {
+
+    private String name;
+    private String location;
+    private Integer capacity;
+
+    public VenueUpdateRequest(String name, String location, int capacity) {
+        this.name = name;
+        this.location = location;
+        this.capacity = capacity;
+    }
+}

--- a/src/main/java/com/woochang/highticket/global/exception/ErrorCode.java
+++ b/src/main/java/com/woochang/highticket/global/exception/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
     AUTH_REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH_REFRESH_TOKEN_EXPIRED", "Refresh Token이 만료되어 재인증이 필요합니다."),
 
     COMMON_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON_NOT_FOUND", "리소스를 찾을 수 없습니다."),
+    VENUE_NOT_FOUND(HttpStatus.NOT_FOUND, "VENUE_NOT_FOUND", "해당 ID에 해당하는 행사장을 찾을 수 없습니다."),
 
     // 5xx 서버 오류
     GLOBAL_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "GLOBAL_INTERNAL_SERVER_ERROR", "서버 오류 입니다.");

--- a/src/main/java/com/woochang/highticket/global/exception/ErrorCode.java
+++ b/src/main/java/com/woochang/highticket/global/exception/ErrorCode.java
@@ -2,25 +2,30 @@ package com.woochang.highticket.global.exception;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
     // 4xx 클라이언트 오류
-    INVALID_INPUT(400, "INVALID_INPUT", "잘못된 입력입니다."),
-    VALIDATION_FAILED(400, "VALIDATION_FAILED", "입력값 검증에 실패했습니다."),
+    COMMON_INVALID_INPUT(HttpStatus.BAD_REQUEST, "COMMON_INVALID_INPUT", "잘못된 입력입니다."),
+    COMMON_VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "COMMON_VALIDATION_FAILED", "입력값 검증에 실패했습니다."),
 
-    AUTHENTICATION_FAILED(401, "AUTHENTICATION_FAILED", "인증에 실패했습니다."),
-    REQUIRED_PERMISSION(401, "REQUIRED_PERMISSION", "권한이 필요합니다."),
-    INVALID_TOKEN(401, "INVALID_TOKEN", "유효하지 않은 토큰입니다."),
-    REFRESH_TOKEN_EXPIRED(401, "REFRESH_TOKEN_EXPIRED", "Refresh Token이 만료되어 재인증이 필요합니다."),
+    AUTH_AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "AUTH_AUTHENTICATION_FAILED", "인증에 실패했습니다."),
+    AUTH_REQUIRED_PERMISSION(HttpStatus.UNAUTHORIZED, "AUTH_REQUIRED_PERMISSION", "권한이 필요합니다."),
+    AUTH_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_INVALID_TOKEN", "유효하지 않은 토큰입니다."),
+    AUTH_REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH_REFRESH_TOKEN_EXPIRED", "Refresh Token이 만료되어 재인증이 필요합니다."),
 
-    NOT_FOUND(404, "NOT_FOUND", "리소스를 찾을 수 없습니다."),
+    COMMON_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON_NOT_FOUND", "리소스를 찾을 수 없습니다."),
 
     // 5xx 서버 오류
-    INTERNAL_SERVER_ERROR(500, "INTERNAL_SERVER_ERROR", "서버 오류 입니다.");
+    GLOBAL_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "GLOBAL_INTERNAL_SERVER_ERROR", "서버 오류 입니다.");
 
-    private final int status; // 상태 코드
+    private final HttpStatus status; // 상태 코드
     private final String code; // 도메인 기반 응답 코드
     private final String message; // 사용자에게 전달할 메시지
+
+    public int getStatus() {
+        return status.value();
+    }
 }

--- a/src/main/java/com/woochang/highticket/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/woochang/highticket/global/exception/GlobalExceptionHandler.java
@@ -24,10 +24,10 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponse<?>> handleException(Exception e) {
         log.error("예상하지 못한 오류 발생: ", e);
         return ResponseEntity
-                .status(ErrorCode.INTERNAL_SERVER_ERROR.getStatus())
+                .status(ErrorCode.GLOBAL_INTERNAL_SERVER_ERROR.getStatus())
                 .body(ApiResponse.error(
-                        ErrorCode.INTERNAL_SERVER_ERROR.getCode(),
-                        ErrorCode.INTERNAL_SERVER_ERROR.getMessage()
+                        ErrorCode.GLOBAL_INTERNAL_SERVER_ERROR.getCode(),
+                        ErrorCode.GLOBAL_INTERNAL_SERVER_ERROR.getMessage()
                 ));
     }
 }

--- a/src/main/java/com/woochang/highticket/repository/venue/VenueRepository.java
+++ b/src/main/java/com/woochang/highticket/repository/venue/VenueRepository.java
@@ -1,0 +1,7 @@
+package com.woochang.highticket.repository.venue;
+
+import com.woochang.highticket.domain.venue.Venue;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VenueRepository extends JpaRepository<Venue, Long> {
+}

--- a/src/main/java/com/woochang/highticket/service/auth/TokenService.java
+++ b/src/main/java/com/woochang/highticket/service/auth/TokenService.java
@@ -33,14 +33,14 @@ public class TokenService {
     public TokenDto reissueToken(String refreshToken) {
 
         if (!jwtTokenProvider.validateToken(refreshToken)) {
-            throw new InvalidTokenException(ErrorCode.INVALID_TOKEN);
+            throw new InvalidTokenException(ErrorCode.AUTH_INVALID_TOKEN);
         }
 
         String userId = jwtTokenProvider.getUserId(refreshToken);
         String storedToken = redisService.getRefreshToken(userId);
 
         if (!refreshToken.equals(storedToken)) {
-            throw new InvalidTokenException(ErrorCode.REFRESH_TOKEN_EXPIRED);
+            throw new InvalidTokenException(ErrorCode.AUTH_REFRESH_TOKEN_EXPIRED);
         }
 
         CustomOAuth2User customOAuth2User = customOAuth2UserService.loadByUserId(userId);

--- a/src/main/java/com/woochang/highticket/service/venue/VenueService.java
+++ b/src/main/java/com/woochang/highticket/service/venue/VenueService.java
@@ -1,0 +1,42 @@
+package com.woochang.highticket.service.venue;
+
+import com.woochang.highticket.domain.venue.Venue;
+import com.woochang.highticket.dto.venue.VenueCreateRequest;
+import com.woochang.highticket.dto.venue.VenueUpdateRequest;
+import com.woochang.highticket.global.exception.BusinessException;
+import com.woochang.highticket.global.exception.ErrorCode;
+import com.woochang.highticket.repository.venue.VenueRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class VenueService {
+
+    private final VenueRepository venueRepository;
+
+    public void createVenue(VenueCreateRequest request) {
+        venueRepository.save(Venue.of(request));
+    }
+
+    public List<Venue> findAll() {
+        return venueRepository.findAll();
+    }
+
+    public Venue findVenue(Long id) {
+        return venueRepository.findById(id).orElseThrow(() -> new BusinessException(ErrorCode.VENUE_NOT_FOUND));
+    }
+
+    @Transactional
+    public void updateVenue(Long id, VenueUpdateRequest request) {
+        Venue venue = venueRepository.findById(id).orElseThrow(() -> new BusinessException(ErrorCode.VENUE_NOT_FOUND));
+        venue.updateWith(request);
+    }
+
+    public void deleteVenue(Long id) {
+        venueRepository.deleteById(id);
+    }
+}

--- a/src/test/java/com/woochang/highticket/service/auth/TokenServiceTest.java
+++ b/src/test/java/com/woochang/highticket/service/auth/TokenServiceTest.java
@@ -107,7 +107,7 @@ class TokenServiceTest {
         String fakeToken = "invalidRefreshToken";
 
         // when & then
-        assertInvalidTokenException(() -> tokenService.reissueToken(fakeToken), ErrorCode.INVALID_TOKEN);
+        assertInvalidTokenException(() -> tokenService.reissueToken(fakeToken), ErrorCode.AUTH_INVALID_TOKEN);
     }
 
 
@@ -118,7 +118,7 @@ class TokenServiceTest {
         String refreshToken = jwtTokenProvider.createRefreshToken(auth);
 
         // when & then
-        assertInvalidTokenException(() -> tokenService.reissueToken(refreshToken), ErrorCode.REFRESH_TOKEN_EXPIRED);
+        assertInvalidTokenException(() -> tokenService.reissueToken(refreshToken), ErrorCode.AUTH_REFRESH_TOKEN_EXPIRED);
     }
 
     @Test
@@ -134,7 +134,7 @@ class TokenServiceTest {
 
         // then
         assertNull(redisService.getRefreshToken(savedUser.getUserIdString()));
-        assertInvalidTokenException(() -> tokenService.reissueToken(dto.getRefreshToken()), ErrorCode.REFRESH_TOKEN_EXPIRED);
+        assertInvalidTokenException(() -> tokenService.reissueToken(dto.getRefreshToken()), ErrorCode.AUTH_REFRESH_TOKEN_EXPIRED);
     }
 
     // InvalidTokenException 헬퍼 메서드


### PR DESCRIPTION
## 주요 내용
- Entity, Repository, Service, Controller 구현
- ErrorCode에 VENUE_NOT_FOUND 추가

## 참고
- 이번 PR에 포함된 커밋 중 `Merge branch 'main' into feature/venue` 라는 커밋이 있는데, 이는 의도된 변경 사항이 아니라 중간에 main 브랜치의 변경 사항을 feature 브랜치에 반영했기 때문이며, 실제 기능 구현과는 직접적인 관련이 없음.

## 피드백
**Q. 왜 테스트 코드를 작성하지 않았을까?**
- Postman으로 실제 동작을 확인했고, 비즈니스 로직은 단순한 CRUD 위임이므로 작성하지 않음. 향후 로직이 복잡해지면 반드시 테스트를 도입할 예정.
> 레포지토리에 위임한 경우에도 트랜잭션 처리나 존재 검증 등의 `findById().orElseThrow()` 부분의 예외 케이스에 대한 테스트를 작성해두면 좋다.

**Q. 왜 `CreateRequest`와 `UpdateRequest`를 분리했는가?**
- 사용 목적이 다르다고 판단해서 만들었으나, 실질적인 차이는 적음. 이후 유지보수 시 요청 필드 제약이 달라질 가능성을 염두에 둠.

**Q. 왜 ErrorCode 수정도 함께 했는가?**
- 기능 구현 중 필요한 예외 코드였고 venue 도메인과 연관되어 있어 함께 처리.


