### PR TITLE
fix: OAuth2Config 제거 후 테스트 코드 수정 (HIT-60)

### DIFF
--- a/src/main/java/com/woochang/highticket/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/woochang/highticket/global/security/jwt/JwtTokenProvider.java
@@ -56,7 +56,7 @@ public class JwtTokenProvider {
 
         return Jwts.builder()
                 .subject(userId)
-                .claim("email",user.getEmail())
+                .claim("email", user.getEmail())
                 .claim("name", user.getNickname())
                 .claim("role", user.getRole())
                 .issuedAt(now)
@@ -102,6 +102,7 @@ public class JwtTokenProvider {
             return false;
         }
     }
+
     // 토큰에서 사용자 ID 추출
     public String getUserId(String jwt) {
         return parseClaims(jwt).getSubject();
@@ -132,31 +133,5 @@ public class JwtTokenProvider {
                 .build()
                 .parseSignedClaims(jwt)
                 .getPayload();
-    }
-
-    // Access Token 만료 테스트 전용 메서드
-    public String createExpiredAccessToken(String subject) {
-        Date now = new Date();
-        Date expiry = new Date(now.getTime() - 1000); // 만료
-
-        return Jwts.builder()
-                .subject(subject)
-                .issuedAt(now)
-                .expiration(expiry)
-                .signWith(privateKey)
-                .compact();
-    }
-
-    // Refresh Token 만료 테스트 전용 메서드
-    public String createExpiredRefreshToken(String subject) {
-        Date now = new Date();
-        Date expiry = new Date(now.getTime() - 1000); // 만료
-
-        return Jwts.builder()
-                .subject(subject)
-                .issuedAt(now)
-                .expiration(expiry)
-                .signWith(privateKey)
-                .compact();
     }
 }

--- a/src/test/java/com/woochang/highticket/service/auth/TokenServiceTest.java
+++ b/src/test/java/com/woochang/highticket/service/auth/TokenServiceTest.java
@@ -1,6 +1,5 @@
 package com.woochang.highticket.service.auth;
 
-import com.woochang.highticket.OAuth2TestConfig;
 import com.woochang.highticket.domain.user.LoginType;
 import com.woochang.highticket.domain.user.User;
 import com.woochang.highticket.domain.user.security.CustomOAuth2User;
@@ -8,103 +7,154 @@ import com.woochang.highticket.dto.auth.TokenDto;
 import com.woochang.highticket.global.exception.ErrorCode;
 import com.woochang.highticket.global.exception.InvalidTokenException;
 import com.woochang.highticket.global.security.jwt.JwtTokenProvider;
-import com.woochang.highticket.repository.user.UserRepository;
+import com.woochang.highticket.global.security.oauth2.OAuth2Attribute;
+import com.woochang.highticket.service.user.CustomOAuth2UserService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
-@SpringBootTest
-@Transactional
-@ActiveProfiles("test")
-@Import(OAuth2TestConfig.class)
+@ExtendWith(MockitoExtension.class)
 class TokenServiceTest {
 
-    @Autowired
-    TokenService tokenService;
-    @Autowired
-    RedisService redisService;
-    @Autowired
-    UserRepository userRepository;
-    @Autowired
-    JwtTokenProvider jwtTokenProvider;
+    @InjectMocks
+    private TokenService tokenService;
 
-    User savedUser;
-    Authentication auth;
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Mock
+    private RedisService redisService;
+
+    @Mock
+    private CustomOAuth2UserService customOAuth2UserService;
+
+    private User user;
+    private Authentication auth;
 
 
     @BeforeEach
     public void setUp() {
-        User user = User.ofOAuth2("test@example.com", "test", LoginType.GOOGLE);
-        savedUser = userRepository.save(user);
-        CustomOAuth2User oAuth2User = new CustomOAuth2User(savedUser, Map.of());
-        auth = new OAuth2AuthenticationToken(oAuth2User, oAuth2User.getAuthorities(), "google");
+        user = User.ofOAuth2("test@example.com", "test", LoginType.GOOGLE);
+
+        ReflectionTestUtils.setField(user, "id", 1L);
+
+        Map<String, Object> attributes = Map.of(
+                "email", "test@example.com",
+                "name", "test",
+                "loginType", "google"
+        );
+        OAuth2Attribute oAuth2Attribute = OAuth2Attribute.of("google", attributes);
+
+        CustomOAuth2User customOAuth2User = new CustomOAuth2User(user, oAuth2Attribute.toMap());
+        auth = new OAuth2AuthenticationToken(customOAuth2User, customOAuth2User.getAuthorities(), customOAuth2User.getAttribute("loginType"));
     }
 
     @Test
-    @DisplayName("Access/Refresh 토큰 정상 발급")
-    public void issueToken() {
-        // given -> setUp
+    @DisplayName("Access/Refresh 토큰이 정상적으로 발급된다")
+    public void issueToken_success() {
+        // given
+        String accessToken = "newAccessToken";
+        String refreshToken = "newRefreshToken";
+
+        when(jwtTokenProvider.createAccessToken(auth)).thenReturn(accessToken);
+        when(jwtTokenProvider.createRefreshToken(auth)).thenReturn(refreshToken);
+        when(jwtTokenProvider.getRefreshTokenExpiryMs()).thenReturn(60_000L);
 
         // when
         TokenDto dto = tokenService.issueToken(auth);
 
         // then
+        verify(redisService).saveRefreshToken(user.getUserIdString(), refreshToken, 60_000L);
         assertNotNull(dto.getAccessToken());
         assertNotNull(dto.getRefreshToken());
-        String savedRedisRefreshToken = redisService.getRefreshToken(savedUser.getUserIdString());
-        assertEquals(dto.getRefreshToken(), savedRedisRefreshToken);
+        assertEquals(accessToken, dto.getAccessToken());
+        assertEquals(refreshToken, dto.getRefreshToken());
     }
 
     @Test
-    @DisplayName("정상적인 Refresh Token으로 Access Token 재발급")
-    public void reissueToken_success() {
+    @DisplayName("유효한 Refresh Token으로 Access Token만 재발급")
+    public void reissueToken_accessToken_success() {
         // given
-        String refreshToken = jwtTokenProvider.createRefreshToken(auth);
-        redisService.saveRefreshToken(savedUser.getUserIdString(), refreshToken, jwtTokenProvider.getRefreshTokenExpiryMs());
+        String refreshToken = "refreshToken";
+        String newAccessToken = "newAccessToken";
+        long ttl = 150_000L;
+        long renewThresholdMs = 120_000L;
+
+
+        when(jwtTokenProvider.validateToken(refreshToken)).thenReturn(true);
+        when(jwtTokenProvider.getUserId(refreshToken)).thenReturn(user.getUserIdString());
+        when(redisService.getRefreshToken(user.getUserIdString())).thenReturn(refreshToken);
+        when(customOAuth2UserService.loadByUserId(user.getUserIdString())).thenReturn((CustomOAuth2User) auth.getPrincipal());
+        when(jwtTokenProvider.createAccessToken(auth)).thenReturn(newAccessToken);
+        when(redisService.getTTL(user.getUserIdString())).thenReturn(ttl);
+        when(jwtTokenProvider.getRefreshTokenRenewThresholdMs()).thenReturn(renewThresholdMs);
+
 
         // when
         TokenDto dto = tokenService.reissueToken(refreshToken);
 
         // then
-        String accessToken = dto.getAccessToken();
-        assertNotNull(accessToken);
-        assertEquals(savedUser.getEmail(), jwtTokenProvider.parseClaims(accessToken).get("email", String.class));
+        verify(jwtTokenProvider).createAccessToken(auth);
+        assertNotNull(dto.getAccessToken());
+        assertEquals(refreshToken, dto.getRefreshToken());
     }
 
     @Test
-    @DisplayName("Refresh Token 만료 임박 시 재발급")
-    public void reissueToken_refreshToken() throws InterruptedException {
+    @DisplayName("Refresh Token 만료 임박 시 Refresh Token도 재발급")
+    public void reissueToken_refreshToken_success() {
         // given
-        String oldRefreshToken = jwtTokenProvider.createRefreshToken(auth);
-        redisService.saveRefreshToken(savedUser.getUserIdString(), oldRefreshToken, jwtTokenProvider.getRefreshTokenExpiryMs());
-        Thread.sleep(1000); // 오래된 리프레쉬 토큰이므로 1초후 로직들이 진행되게 함 (처리 속도가 빠르므로 같은 토큰으로 인식하는 문제 해결을 위함)
+        String oldRefreshToken = "oldRefreshToken";
+        String newRefreshToken = "newRefreshToken";
+        String newAccessToken = "newAccessToken";
+        long ttl = 119_000L;
+        long renewThresholdMs = 120_000L;
+        long refreshTokenExpiryMs = 60_000L;
+
+
+        when(jwtTokenProvider.validateToken(oldRefreshToken)).thenReturn(true);
+        when(jwtTokenProvider.getUserId(oldRefreshToken)).thenReturn(user.getUserIdString());
+        when(redisService.getRefreshToken(user.getUserIdString())).thenReturn(oldRefreshToken);
+        when(customOAuth2UserService.loadByUserId(user.getUserIdString())).thenReturn((CustomOAuth2User) auth.getPrincipal());
+        when(jwtTokenProvider.createAccessToken(auth)).thenReturn(newAccessToken);
+        when(redisService.getTTL(user.getUserIdString())).thenReturn(ttl);
+        when(jwtTokenProvider.getRefreshTokenRenewThresholdMs()).thenReturn(renewThresholdMs);
+        when(jwtTokenProvider.createRefreshToken(auth)).thenReturn(newRefreshToken);
+        when(jwtTokenProvider.getRefreshTokenExpiryMs()).thenReturn(refreshTokenExpiryMs);
+        doNothing().when(redisService).saveRefreshToken(user.getUserIdString(), newRefreshToken, refreshTokenExpiryMs);
+
 
         // when
         TokenDto dto = tokenService.reissueToken(oldRefreshToken);
 
         // then
+        verify(jwtTokenProvider).createAccessToken(auth);
+        verify(jwtTokenProvider).createRefreshToken(auth);
+        verify(redisService).saveRefreshToken(user.getUserIdString(), newRefreshToken, refreshTokenExpiryMs);
         assertNotNull(dto.getAccessToken());
         assertNotNull(dto.getRefreshToken());
         assertNotEquals(oldRefreshToken, dto.getRefreshToken());
     }
 
     @Test
-    @DisplayName("Refresh Token이 유효하지 않은 경우 예외 발생")
+    @DisplayName("Refresh Token이 유효하지 않은 경우 예외가 발생한다")
     public void reissueToken_invalidRefreshToken() {
         // given
         String fakeToken = "invalidRefreshToken";
+
+        when(jwtTokenProvider.validateToken(fakeToken)).thenReturn(false);
 
         // when & then
         assertInvalidTokenException(() -> tokenService.reissueToken(fakeToken), ErrorCode.AUTH_INVALID_TOKEN);
@@ -112,29 +162,85 @@ class TokenServiceTest {
 
 
     @Test
-    @DisplayName("Refresh Token은 유효하지만 저장된 토큰이 없는 경우 예외 발생")
+    @DisplayName("Refresh Token은 유효하지만 저장된 토큰이 없는 경우 예외가 발생한다")
     public void reissue_nonExistentRedis() {
         // given
-        String refreshToken = jwtTokenProvider.createRefreshToken(auth);
+        String refreshToken = "refreshToken";
+
+        when(jwtTokenProvider.validateToken(refreshToken)).thenReturn(true);
+        when(jwtTokenProvider.getUserId(refreshToken)).thenReturn(user.getUserIdString());
+        when(redisService.getRefreshToken(user.getUserIdString())).thenReturn(null);
 
         // when & then
         assertInvalidTokenException(() -> tokenService.reissueToken(refreshToken), ErrorCode.AUTH_REFRESH_TOKEN_EXPIRED);
     }
 
     @Test
-    @DisplayName("로그아웃 시 저장된 Refresh Token 삭제 및 재사용 불가")
-    public void logout_tokenCannotBeUsed() {
+    @DisplayName("Redis에 저장된 Refresh Token과 입력된 토큰이 다르면 예외가 발생한다")
+    public void reissue_tokenMismatch() {
         // given
-        TokenDto dto = tokenService.issueToken(auth);
-        String storedRefreshToken = redisService.getRefreshToken(savedUser.getUserIdString());
-        assertThat(storedRefreshToken).isEqualTo(dto.getRefreshToken());
+        String inputToken = "inputToken";
+        String storedToken = "differentToken";
+
+        when(jwtTokenProvider.validateToken(inputToken)).thenReturn(true);
+        when(jwtTokenProvider.getUserId(inputToken)).thenReturn(user.getUserIdString());
+        when(redisService.getRefreshToken(user.getUserIdString())).thenReturn(storedToken);
+
+        // when & then
+        assertInvalidTokenException(() -> tokenService.reissueToken(inputToken), ErrorCode.AUTH_REFRESH_TOKEN_EXPIRED);
+    }
+
+    @Test
+    @DisplayName("만료된 Access Token은 블랙리스트에 등록되지 않는다")
+    void logout_withExpiredAccessToken_doesNotBlacklist() {
+        // given
+        String accessToken = "expiredToken";
+        long remainingExpiryMs = 0L;
+
+        when(jwtTokenProvider.getAccessTokenRemainingExpiryMs(accessToken)).thenReturn(remainingExpiryMs);
 
         // when
-        tokenService.logout(savedUser.getUserIdString(), dto.getAccessToken());
+        tokenService.logout(user.getUserIdString(), accessToken);
 
         // then
-        assertNull(redisService.getRefreshToken(savedUser.getUserIdString()));
-        assertInvalidTokenException(() -> tokenService.reissueToken(dto.getRefreshToken()), ErrorCode.AUTH_REFRESH_TOKEN_EXPIRED);
+        verify(redisService).deleteRefreshToken(user.getUserIdString());
+        verify(redisService, never()).blacklistAccessToken(accessToken, remainingExpiryMs);
+    }
+
+    @Test
+    @DisplayName("이미 블랙리스트에 등록된 토큰은 다시 등록하지 않는다")
+    void logout_alreadyBlacklisted_doesNotReBlacklist() {
+        // given
+        String accessToken = "blacklistedToken";
+        long remainingExpiryMs = 1000L;
+
+        when(jwtTokenProvider.getAccessTokenRemainingExpiryMs(accessToken)).thenReturn(remainingExpiryMs);
+        when(redisService.isBlacklisted(accessToken)).thenReturn(true);
+
+        // when
+        tokenService.logout(user.getUserIdString(), accessToken);
+
+        // then
+        verify(redisService).deleteRefreshToken(user.getUserIdString());
+        verify(redisService, never()).blacklistAccessToken(accessToken, remainingExpiryMs);
+    }
+
+    @Test
+    @DisplayName("유효한 Access Token은 블랙리스트에 등록된다")
+    void logout_validToken_addsToBlacklist() {
+        // given
+        String accessToken = "validToken";
+        long remainingExpiryMs = 3000L;
+
+        when(jwtTokenProvider.getAccessTokenRemainingExpiryMs(accessToken)).thenReturn(remainingExpiryMs);
+        when(redisService.isBlacklisted(accessToken)).thenReturn(false);
+
+        // when
+        tokenService.logout(user.getUserIdString(), accessToken);
+
+        // then
+        verify(redisService).deleteRefreshToken(user.getUserIdString());
+        verify(redisService).blacklistAccessToken(accessToken, remainingExpiryMs);
     }
 
     // InvalidTokenException 헬퍼 메서드
@@ -142,6 +248,5 @@ class TokenServiceTest {
         InvalidTokenException ex = assertThrows(InvalidTokenException.class, executable::run);
         assertThat(ex.getErrorCode()).isEqualTo(expectedErrorCode);
         assertThat(ex.getMessage()).isEqualTo(expectedErrorCode.getMessage());
-
     }
 }

--- a/src/test/java/com/woochang/highticket/support/JwtTestUtils.java
+++ b/src/test/java/com/woochang/highticket/support/JwtTestUtils.java
@@ -1,0 +1,31 @@
+package com.woochang.highticket.support;
+
+import io.jsonwebtoken.Jwts;
+
+import java.security.PrivateKey;
+import java.util.Date;
+
+public class JwtTestUtils {
+
+    public static String createExpiredAccessToken(PrivateKey privateKey, String subject) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() - 1000);
+        return Jwts.builder()
+                .subject(subject)
+                .issuedAt(now)
+                .expiration(expiry)
+                .signWith(privateKey)
+                .compact();
+    }
+
+    public static String createExpiredRefreshToken(PrivateKey privateKey, String subject) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() - 1000);
+        return Jwts.builder()
+                .subject(subject)
+                .issuedAt(now)
+                .expiration(expiry)
+                .signWith(privateKey)
+                .compact();
+    }
+}


### PR DESCRIPTION
### 주요 변경 사항
- `OAuth2Config`가 테스트 환경에서 불필요하게 `import` 되어 테스트 실행 오류가 발생
- 해당 설정을 제거하고 `JwtTokenProviderTest`, `TokenServiceTest`를 순수 단위 테스트로 전환
- 운영 코드에 포함되어 있던 테스트 전용 메서드를 `JwtTestUtils` 클래스로 분리하여 테스트의 독립성과 의도를 강화