### PR TITLE
refactor: API 응답 구조 리팩토링 (HIT-62)

### DIFF
--- a/src/main/java/com/woochang/highticket/controller/performance/PerformanceController.java
+++ b/src/main/java/com/woochang/highticket/controller/performance/PerformanceController.java
@@ -14,6 +14,8 @@ import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
+import static com.woochang.highticket.global.response.SuccessCode.*;
+
 @RestController
 @RequestMapping("/performances")
 @RequiredArgsConstructor
@@ -27,7 +29,9 @@ public class PerformanceController {
         return Mono.fromCallable(() -> {
             Performance performance = performanceService.createPerformance(request);
             PerformanceResponse response = performanceMapper.toResponse(performance);
-            return ResponseEntity.ok(ApiResponse.success(response));
+            return ResponseEntity
+                    .status(PERFORMANCE_CREATED.getStatus())
+                    .body(ApiResponse.success(PERFORMANCE_CREATED, response));
         });
     }
 
@@ -36,7 +40,9 @@ public class PerformanceController {
         return Mono.fromCallable(() -> {
             Performance performance = performanceService.findPerformance(id);
             PerformanceResponse response = performanceMapper.toResponse(performance);
-            return ResponseEntity.ok(ApiResponse.success(response));
+            return ResponseEntity
+                    .status(OK.getStatus())
+                    .body(ApiResponse.success(OK, response));
         });
     }
 
@@ -45,7 +51,9 @@ public class PerformanceController {
         return Mono.fromCallable(() -> {
                     Performance performance = performanceService.updatePerformance(id, request);
                     PerformanceResponse response = performanceMapper.toResponse(performance);
-                    return ResponseEntity.ok(ApiResponse.success(response));
+                    return ResponseEntity
+                            .status(PERFORMANCE_UPDATED.getStatus())
+                            .body(ApiResponse.success(PERFORMANCE_UPDATED, response));
                 })
                 .subscribeOn(Schedulers.boundedElastic());
     }
@@ -54,7 +62,9 @@ public class PerformanceController {
     public Mono<ResponseEntity<ApiResponse<Void>>> deletePerformance(@PathVariable Long id) {
         return Mono.fromCallable(() -> {
             performanceService.deletePerformance(id);
-            return ResponseEntity.ok(ApiResponse.success(null));
+            return ResponseEntity
+                    .status(PERFORMANCE_DELETED.getStatus())
+                    .body(ApiResponse.success(PERFORMANCE_DELETED));
         });
     }
 }

--- a/src/main/java/com/woochang/highticket/controller/performance/schedule/PerformanceScheduleController.java
+++ b/src/main/java/com/woochang/highticket/controller/performance/schedule/PerformanceScheduleController.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import static com.woochang.highticket.dto.performance.schedule.PerformanceScheduleDto.*;
+import static com.woochang.highticket.global.response.SuccessCode.*;
 
 @RestController
 @RequestMapping("/performance-schedules")
@@ -23,26 +24,34 @@ public class PerformanceScheduleController {
     public ResponseEntity<ApiResponse<Response>> create(@RequestBody @Valid Create request) {
         PerformanceSchedule schedule = scheduleService.createSchedule(request);
         Response response = scheduleMapper.toResponse(schedule);
-        return ResponseEntity.ok(ApiResponse.success(response));
+        return ResponseEntity
+                .status(PERFORMANCE_SCHEDULE_CREATED.getStatus())
+                .body(ApiResponse.success(PERFORMANCE_SCHEDULE_CREATED, response));
     }
 
     @GetMapping("/{id}")
     public ResponseEntity<ApiResponse<Response>> getSchedule(@PathVariable Long id) {
         PerformanceSchedule schedule = scheduleService.getSchedule(id);
         Response response = scheduleMapper.toResponse(schedule);
-        return ResponseEntity.ok(ApiResponse.success(response));
+        return ResponseEntity
+                .status(OK.getStatus())
+                .body(ApiResponse.success(OK, response));
     }
 
     @PatchMapping("/{id}")
     public ResponseEntity<ApiResponse<Response>> update(@PathVariable Long id, @RequestBody @Valid Update request) {
         PerformanceSchedule schedule = scheduleService.updateSchedule(id, request);
         Response response = scheduleMapper.toResponse(schedule);
-        return ResponseEntity.ok(ApiResponse.success(response));
+        return ResponseEntity
+                .status(PERFORMANCE_SCHEDULE_UPDATED.getStatus())
+                .body(ApiResponse.success(PERFORMANCE_SCHEDULE_UPDATED, response));
     }
 
     @DeleteMapping("/{id}")
     public ResponseEntity<ApiResponse<Void>> delete(@PathVariable Long id) {
         scheduleService.deleteSchedule(id);
-        return ResponseEntity.ok(ApiResponse.success(null));
+        return ResponseEntity
+                .status(PERFORMANCE_SCHEDULE_DELETED.getStatus())
+                .body(ApiResponse.success(PERFORMANCE_SCHEDULE_DELETED));
     }
 }

--- a/src/main/java/com/woochang/highticket/controller/venue/VenueController.java
+++ b/src/main/java/com/woochang/highticket/controller/venue/VenueController.java
@@ -12,6 +12,8 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+import static com.woochang.highticket.global.response.SuccessCode.*;
+
 @RestController
 @RequestMapping("/venues")
 @RequiredArgsConstructor
@@ -22,30 +24,40 @@ public class VenueController {
     @GetMapping
     public ResponseEntity<ApiResponse<List<Venue>>> getAllVenues() {
         List<Venue> venues = venueService.findAll();
-        return ResponseEntity.ok(ApiResponse.success(venues));
+        return ResponseEntity
+                .status(OK.getStatus())
+                .body(ApiResponse.success(OK, venues));
     }
 
     @GetMapping("/{id}")
     public ResponseEntity<ApiResponse<Venue>> getVenue(@PathVariable Long id) {
         Venue venue = venueService.findVenue(id);
-        return ResponseEntity.ok(ApiResponse.success(venue));
+        return ResponseEntity
+                .status(OK.getStatus())
+                .body(ApiResponse.success(OK, venue));
     }
 
     @PostMapping
     public ResponseEntity<ApiResponse<Void>> createVenue(@RequestBody @Valid VenueCreateRequest request) {
         venueService.createVenue(request);
-        return ResponseEntity.ok(ApiResponse.success(null));
+        return ResponseEntity
+                .status(VENUE_CREATED.getStatus())
+                .body(ApiResponse.success(VENUE_CREATED));
     }
 
     @PatchMapping("/{id}")
     public ResponseEntity<ApiResponse<Void>> updateVenue(@PathVariable Long id, @RequestBody @Valid VenueUpdateRequest request) {
         venueService.updateVenue(id, request);
-        return ResponseEntity.ok(ApiResponse.success(null));
+        return ResponseEntity
+                .status(VENUE_UPDATED.getStatus())
+                .body(ApiResponse.success(VENUE_UPDATED));
     }
 
     @DeleteMapping("/{id}")
     public ResponseEntity<ApiResponse<Void>> deleteVenue(@PathVariable Long id) {
         venueService.deleteVenue(id);
-        return ResponseEntity.ok(ApiResponse.success(null));
+        return ResponseEntity
+                .status(VENUE_DELETED.getStatus())
+                .body(ApiResponse.success(VENUE_DELETED));
     }
 }

--- a/src/main/java/com/woochang/highticket/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/woochang/highticket/global/exception/GlobalExceptionHandler.java
@@ -18,10 +18,9 @@ public class GlobalExceptionHandler {
     // 서비스 로직 예외 처리
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<ApiResponse<?>> handleBusinessException(BusinessException e) {
-        ErrorCode errorCode = e.getErrorCode();
         return ResponseEntity
-                .status(errorCode.getStatus())
-                .body(ApiResponse.error(errorCode.getCode(), errorCode.getMessage()));
+                .status(e.getErrorCode().getStatus())
+                .body(ApiResponse.error(e.getErrorCode()));
     }
 
     // 예기치 못한 예외 처리
@@ -30,10 +29,7 @@ public class GlobalExceptionHandler {
         log.error("예상하지 못한 오류 발생: ", e);
         return ResponseEntity
                 .status(ErrorCode.GLOBAL_INTERNAL_SERVER_ERROR.getStatus())
-                .body(ApiResponse.error(
-                        ErrorCode.GLOBAL_INTERNAL_SERVER_ERROR.getCode(),
-                        ErrorCode.GLOBAL_INTERNAL_SERVER_ERROR.getMessage()
-                ));
+                .body(ApiResponse.error(ErrorCode.GLOBAL_INTERNAL_SERVER_ERROR));
     }
 
     //
@@ -41,11 +37,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponse<?>> handleServerWebInputException() {
         return ResponseEntity
                 .status(ErrorCode.INVALID_JSON_REQUEST.getStatus())
-                .body(
-                        ApiResponse.error(
-                                ErrorCode.INVALID_JSON_REQUEST.getCode(),
-                                ErrorCode.INVALID_JSON_REQUEST.getMessage()
-                        ));
+                .body(ApiResponse.error(ErrorCode.INVALID_JSON_REQUEST));
     }
 
     @ExceptionHandler(WebExchangeBindException.class)
@@ -61,8 +53,6 @@ public class GlobalExceptionHandler {
 
         return ResponseEntity
                 .status(ErrorCode.COMMON_VALIDATION_FAILED.getStatus())
-                .body(
-                        ApiResponse.error(ErrorCode.COMMON_VALIDATION_FAILED.getCode(), message)
-                );
+                .body(ApiResponse.error(ErrorCode.COMMON_VALIDATION_FAILED, message));
     }
 }

--- a/src/main/java/com/woochang/highticket/global/response/ApiResponse.java
+++ b/src/main/java/com/woochang/highticket/global/response/ApiResponse.java
@@ -1,9 +1,13 @@
 package com.woochang.highticket.global.response;
 
+import com.woochang.highticket.global.exception.ErrorCode;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ApiResponse<T> {
 
     private boolean success;
@@ -19,25 +23,36 @@ public class ApiResponse<T> {
         this.data = data;
     }
 
-    protected ApiResponse(){}
+    public static ApiResponse<Void> success(SuccessCode successCode) {
+        return ApiResponse.<Void>builder()
+                .success(true)
+                .code(successCode.getCode())
+                .message(successCode.getMessage())
+                .build();
+    }
 
-    // 성공 응답
-    public static <T> ApiResponse<T> success(T data) {
+    public static <T> ApiResponse<T> success(SuccessCode successCode, T data) {
         return ApiResponse.<T>builder()
                 .success(true)
-                .code("200")
-                .message("요청이 성공했습니다.")
+                .code(successCode.getCode())
+                .message(successCode.getMessage())
                 .data(data)
                 .build();
     }
 
-    // 실패 응답
-    public static <T> ApiResponse<T> error(String code, String message) {
+    public static <T> ApiResponse<T> error(ErrorCode errorCode) {
         return ApiResponse.<T>builder()
                 .success(false)
-                .code(code)
+                .code(errorCode.getCode())
+                .message(errorCode.getMessage())
+                .build();
+    }
+
+    public static <T> ApiResponse<T> error(ErrorCode errorCode, String message) {
+        return ApiResponse.<T>builder()
+                .success(false)
+                .code(errorCode.getCode())
                 .message(message)
-                .data(null)
                 .build();
     }
 }

--- a/src/main/java/com/woochang/highticket/global/response/SuccessCode.java
+++ b/src/main/java/com/woochang/highticket/global/response/SuccessCode.java
@@ -1,0 +1,35 @@
+package com.woochang.highticket.global.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+@Getter
+public enum SuccessCode {
+    OK(HttpStatus.OK, "OK", "요청이 성공했습니다."),
+
+
+    // 공연
+    PERFORMANCE_CREATED(HttpStatus.CREATED, "PERFORMANCE_CREATED", "공연이 생성되었습니다."),
+    PERFORMANCE_UPDATED(HttpStatus.OK, "PERFORMANCE_UPDATED", "공연이 수정되었습니다."),
+    PERFORMANCE_DELETED(HttpStatus.NO_CONTENT, "PERFORMANCE_DELETED", "공연이 삭제되었습니다."),
+
+    // 공연장
+    VENUE_CREATED(HttpStatus.CREATED, "VENUE_CREATED", "공연장이 생성되었습니다."),
+    VENUE_UPDATED(HttpStatus.OK, "VENUE_UPDATED", "공연장이 수정되었습니다."),
+    VENUE_DELETED(HttpStatus.NO_CONTENT, "VENUE_DELETED", "공연장이 삭제되었습니다."),
+
+    // 공연 일정
+    PERFORMANCE_SCHEDULE_CREATED(HttpStatus.CREATED, "PERFORMANCE_CREATED", "공연 일정이 생성되었습니다."),
+    PERFORMANCE_SCHEDULE_UPDATED(HttpStatus.OK, "PERFORMANCE_CREATED", "공연 일정이 수정되었습니다."),
+    PERFORMANCE_SCHEDULE_DELETED(HttpStatus.NO_CONTENT, "PERFORMANCE_CREATED", "공연 일정이 삭제되었습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    public int getStatus() {
+        return status.value();
+    }
+}


### PR DESCRIPTION
## 주요 내용
- `ApiResponse`의 `success(..)` 응답 구조 리팩토링 및 `error(...)` 개선
- `SuccessCode` enum추가
   - enum 네이밍은 기존 `ErrorCode`와 일관성을 유지
- 기존 `success`, `error` 메서드를 사용하던 `Controller` 및 `GlobalExceptionHandler` 코드 수정

## 추후 설계 전략
- `error`에서 `data`에  상세 에러 정보 (필드 + 메시지 리스트를 담아서 명확한 피드백을 제공